### PR TITLE
[issue-107] Make requests collapsed

### DIFF
--- a/src/components/TheApiVisualizer.vue
+++ b/src/components/TheApiVisualizer.vue
@@ -5,29 +5,29 @@
       v-for="request in $store.state.apiVisualizer.apiRequests"
       class="accordion-item"
     >
-      <h2 class="accordion-header" id="headingOne">
+      <h2 class="accordion-header" :id="`request_${request.id}`">
         <button
-          class="accordion-button"
+          class="accordion-button collapsed"
           type="button"
           data-bs-toggle="collapse"
-          :data-bs-target="`#collapseOne${request.id}`"
-          aria-expanded="true"
-          aria-controls="collapseOne"
+          :data-bs-target="`#collapse_${request.id}`"
+          aria-expanded="false"
+          :aria-controls="`collapse_${request.id}`"
         >
           {{ request.path }} ... responded with {{ request.status }}
         </button>
       </h2>
       <div
-        :id="`collapseOne${request.id}`"
-        class="accordion-collapse collapse show"
-        aria-labelledby="headingOne"
+        :id="`collapse_${request.id}`"
+        class="accordion-collapse collapse"
+        :aria-labelledby="`request_${request.id}`"
         data-bs-parent="#apiRequests"
       >
         <div class="accordion-body">
-          <pre v-if="objectPresent(request.payload)"
+          <pre v-if="isObjectPresent(request.payload)"
             >{{ prettyJson(request.payload) }}
           </pre>
-          <pre v-if="objectPresent(request.response)"
+          <pre v-if="isObjectPresent(request.response)"
             >{{ prettyJson(request.response) }}
           </pre>
         </div>
@@ -39,7 +39,7 @@
 export default {
   name: "TheApiVisualizer",
   methods: {
-    objectPresent(object) {
+    isObjectPresent(object) {
       return object && Object.keys(object).length > 0;
     },
     prettyJson(object) {


### PR DESCRIPTION
## Proposed changes

The API Request Visualizer is cool but we don't need to have the requests be expanded as they are made. This changes the default to show them as collapsed.

#### Before
![Screen Shot 2022-09-13 at 8 39 55 AM](https://user-images.githubusercontent.com/11019755/189917117-7b17d6e9-ba50-4881-bb89-21aa2f42ba70.png)

#### After
![Screen Shot 2022-09-13 at 8 39 46 AM](https://user-images.githubusercontent.com/11019755/189917235-7cccea64-cfbf-4bd9-92bc-f6ba7bc1cccc.png)


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Refactor (found a better way to write the code and accomplish the same task)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
