### PR TITLE
Safely handle users with no rankings

### DIFF
--- a/src/views/SunnySorter.vue
+++ b/src/views/SunnySorter.vue
@@ -42,15 +42,20 @@ export default {
     getTopHundredEpisodes() {
       this.$store.dispatch("getTopHundredEpisodes");
     },
+    getFavoriteSeason(seasons) {
+      if (Object.keys(seasons).length < 1) {
+        return 'No Rankings'
+      } else {
+        return Object.keys(seasons).reduce((a, b) => seasons[a] > seasons[b] ? a : b);
+      }
+    }
   },
   computed: {
-    favoriteSeason() {
-      const seasons = this.$store.state.sunnySorter.rankedSeasons
-      return Object.keys(seasons).reduce((a, b) => seasons[a] > seasons[b] ? a : b);
-    },
     favoriteSeasonPublic() {
-      const seasons = this.$store.state.sunnySorter.userRankedSeasons
-      return Object.keys(seasons).reduce((a, b) => seasons[a] > seasons[b] ? a : b);
+      return this.getFavoriteSeason(this.$store.state.sunnySorter.rankedSeasons)
+    },
+    favoriteSeason() {
+      return this.getFavoriteSeason(this.$store.state.sunnySorter.userRankedSeasons)
     },
   },
   created() {


### PR DESCRIPTION
## PR Guidelines
* Keep it concise. A small, in-scope, easy to review pull request is always preferred over bulkier more complex ones. It's ok to split your work effort into more that one PR if you think it will make things easier on the reviewers.
* Provide a thorough description. Explain what your changes do in as simple terms as possible. Give examples of behavior or illustrate with images or diagrams.
* Don't rewrite Git history once other people have seen your PR. This is important for making sure reviewers have a clean picture of your changes.
* We don't enforce signed commits but many employers do so they know the PR came from you. Feel free to [setup signed commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) if you wish. 
* Don't merge someone elses PR unless asked to or the author is unavailable.

## Proposed changes

Describe the big picture of your changes here to communicate to the team why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Refactor (found a better way to write the code and accomplish the same task)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
